### PR TITLE
Rename command to `user reset-password`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-runcommand/reset-passwords
-==========================
+runcommand/reset-password
+=========================
 
 Reset passwords for one or more WordPress users.
 
-[![Build Status](https://travis-ci.org/runcommand/reset-passwords.svg?branch=master)](https://travis-ci.org/runcommand/reset-passwords)
+[![Build Status](https://travis-ci.org/runcommand/reset-password.svg?branch=master)](https://travis-ci.org/runcommand/reset-password)
 
 Quick links: [Using](#using) | [Installing](#installing) | [Contributing](#contributing)
 
@@ -11,7 +11,7 @@ Quick links: [Using](#using) | [Installing](#installing) | [Contributing](#contr
 
 
 ~~~
-wp user reset-passwords <user>...
+wp user reset-password <user>...
 ~~~
 
 **OPTIONS**
@@ -25,10 +25,10 @@ wp user reset-passwords <user>...
 
 Installing this package requires WP-CLI v0.23.0 or greater. Update to the latest stable release with `wp cli update`.
 
-Once you've done so, you can install this package with `wp package install runcommand/reset-passwords`
+Once you've done so, you can install this package with `wp package install runcommand/reset-password`
 
 ## Contributing
 
 Code and ideas are more than welcome.
 
-Please [open an issue](https://github.com/runcommand/reset-passwords/issues) with questions, feedback, and violent dissent. Pull requests are expected to include test coverage.
+Please [open an issue](https://github.com/runcommand/reset-password/issues) with questions, feedback, and violent dissent. Pull requests are expected to include test coverage.

--- a/command.php
+++ b/command.php
@@ -21,4 +21,4 @@ $reset_password_command = function( $args ) {
 	}
 	WP_CLI::success( 'Passwords reset.' );
 };
-WP_CLI::add_command( 'user reset-passwords', $reset_password_command );
+WP_CLI::add_command( 'user reset-password', $reset_password_command );

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "runcommand/reset-passwords",
+    "name": "runcommand/reset-password",
     "description": "Reset passwords for one or more WordPress users.",
     "license": "MIT",
     "authors": [
@@ -20,7 +20,7 @@
     },
     "extras": {
         "commands": [
-            "user reset-passwords"
+            "user reset-password"
         ]
     }
 }

--- a/features/reset-password.feature
+++ b/features/reset-password.feature
@@ -6,7 +6,7 @@ Feature: Reset passwords for one or more WordPress users.
     When I run `wp user get 1 --field=user_pass`
     Then save STDOUT as {ORIGINAL_PASSWORD}
 
-    When I run `wp user reset-passwords 1`
+    When I run `wp user reset-password 1`
     Then STDOUT should contain:
       """
       Reset password for admin.


### PR DESCRIPTION
This fits in with the singular naming throughout WP-CLI
